### PR TITLE
Fix: Formidable date picker styles override Calendar styles

### DIFF
--- a/admin/class-calendar-plus-admin.php
+++ b/admin/class-calendar-plus-admin.php
@@ -59,6 +59,7 @@ class Calendar_Plus_Admin {
 		$this->version = $version;
 		$this->meta_boxes = array();
 		$this->menu_pages = array();
+		include_once calendarp_get_plugin_dir() . 'admin/integration/integration.php';
 
 		require_once calendarp_get_plugin_dir() . 'admin/meta-boxes/event/class-event-details-meta-box.php';
 

--- a/admin/integration/integration.php
+++ b/admin/integration/integration.php
@@ -1,0 +1,8 @@
+<?php
+
+if (
+	is_plugin_active( 'formidable/formidable.php' ) ||
+	is_plugin_active( 'formidable/pro/formidable-pro.php' )
+) {
+	include_once calendarp_get_plugin_dir() . 'admin/integration/plugins/formidable.php';
+}

--- a/admin/integration/plugins/formidable.php
+++ b/admin/integration/plugins/formidable.php
@@ -1,0 +1,26 @@
+<?php
+add_action( 'admin_print_styles', 'calendarp_event_datepicker_fix' );
+
+function calendarp_event_datepicker_fix() {
+	$screen = get_current_screen();
+	if (
+		$screen &&
+		'post' === $screen->base &&
+		'calendar_event' === $screen->post_type
+	) {
+		echo '<style>
+				.ui-datepicker-calendar thead th{
+					background: #ffffff !important;
+					color: #444 !important;
+				}
+				#ui-datepicker-div .ui-datepicker-header{
+					 background-color: #34495e !important;
+				}
+
+				#ui-datepicker-div .ui-datepicker-year,
+				#ui-datepicker-div .ui-datepicker-month {
+					color: #dadada !important;
+				}
+			  </style>';
+	}
+}


### PR DESCRIPTION
Formidable UI custom styles can override styles of date picker on the event editor screen